### PR TITLE
AWS_ACCOUNT_ID is now referenced as a secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Push to ECR
         run: |
-          aws ecr get-login-password --region ${{ env.AWS_REGION }} | docker login --username AWS --password-stdin ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+          aws ecr get-login-password --region ${{ env.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
           docker build --compress -t ${{ vars.ECR_REPO_HASH_LAMBDA }}:$GITHUB_SHA process/
           docker push ${{ vars.ECR_REPO_HASH_LAMBDA }}:$GITHUB_SHA
 


### PR DESCRIPTION
Fixed a reference where I still use secrets, as opposed to vars.

I wonder if this will actually work if it will break. We'll find out.